### PR TITLE
Remove ellipsis dep for rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     generics,
     pillar,
     purrr,
-    rlang,
+    rlang (>= 1.0.0),
     tibble,
     tidyselect,
     vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,6 @@ RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Imports: 
     dplyr,
-    ellipsis,
     generics,
     pillar,
     purrr,
@@ -27,7 +26,6 @@ Imports:
     tidyselect,
     vctrs
 Suggests: 
-    covr,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 URL: https://github.com/UchidaMizuki/stickyr

--- a/R/sticky_tbl_df.R
+++ b/R/sticky_tbl_df.R
@@ -106,7 +106,7 @@ as_sticky_tibble.sticky_tbl_df <- function(x, ...) {
 #' @importFrom dplyr ungroup
 #' @export
 ungroup.sticky_tbl_df <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   x
 }
 


### PR DESCRIPTION
Since ellipsis is deprecated https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0

Also removed `covr` from Suggests since it is only used via gh action and gh actions installs the package automatically!

Since stickyr has `@import rlang`, no need to prefix `check_dots_empty()`